### PR TITLE
[feat/#36] 홈 카드뷰 구현

### DIFF
--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Cell/HomeCardCell.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Cell/HomeCardCell.swift
@@ -1,0 +1,102 @@
+//
+//  HomeCardCell.swift
+//  HYUNDAICARDDIVE_iOS
+//
+//  Created by 조영서 on 5/17/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+import Kingfisher
+
+final class HomeCardCell: BaseCollectionViewCell {
+
+    // MARK: - UI Components
+
+    private let imageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.layer.cornerRadius = 7
+        $0.clipsToBounds = true
+    }
+
+    private let categoryLabel = UILabel.paddedLabel(top: 2, left: 10, bottom: 2, right: 10).then {
+        $0.font = .custom(.ns_sb_9)
+        $0.textColor = .black
+        $0.backgroundColor = .white
+        $0.textAlignment = .center
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 13
+    }
+
+    private let titleLabel = UILabel().then {
+        $0.font = .custom(.ns_b_16)
+        $0.textColor = .white
+        $0.numberOfLines = 2
+        $0.textAlignment = .center
+    }
+
+    private let subtitleLabel = UILabel().then {
+        $0.font = .custom(.ns_sb_9)
+        $0.textColor = .white
+        $0.numberOfLines = 2
+        $0.textAlignment = .center
+    }
+
+    // MARK: - Override
+
+    override func setUI() {
+        contentView.addSubviews(
+            imageView,
+            categoryLabel,
+            titleLabel,
+            subtitleLabel
+        )
+    }
+
+    override func setLayout() {
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        let textStack = UIStackView(arrangedSubviews: [categoryLabel, titleLabel, subtitleLabel]).then {
+            $0.axis = .vertical
+            $0.alignment = .center
+            $0.spacing = 7
+        }
+
+        contentView.addSubview(textStack)
+
+        textStack.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.leading.greaterThanOrEqualToSuperview().offset(16)
+            $0.trailing.lessThanOrEqualToSuperview().offset(-16)
+        }
+
+        categoryLabel.snp.makeConstraints {
+            $0.height.greaterThanOrEqualTo(20)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.width.lessThanOrEqualToSuperview().offset(-12)
+        }
+
+        subtitleLabel.snp.makeConstraints {
+            $0.height.greaterThanOrEqualTo(18)
+        }
+    }
+
+    // MARK: - Functions
+
+    func configure(with model: HomeCardModel) {
+        if let url = URL(string: model.imageUrl), model.imageUrl.hasPrefix("http") {
+            imageView.kf.setImage(with: url)
+        } else {
+            imageView.image = UIImage(named: model.imageUrl)
+        }
+
+        categoryLabel.text = model.category
+        titleLabel.text = model.title
+        subtitleLabel.text = model.subtitle
+    }
+}

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Cell/HomeCardCell.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Cell/HomeCardCell.swift
@@ -7,51 +7,51 @@
 
 import UIKit
 import SnapKit
-import Then
 import Kingfisher
 
 final class HomeCardCell: BaseCollectionViewCell {
 
     // MARK: - UI Components
 
-    private let imageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFill
-        $0.layer.cornerRadius = 7
-        $0.clipsToBounds = true
-    }
-
-    private let categoryLabel = UILabel.paddedLabel(top: 2, left: 10, bottom: 2, right: 10).then {
-        $0.font = .custom(.ns_sb_9)
-        $0.textColor = .black
-        $0.backgroundColor = .white
-        $0.textAlignment = .center
-        $0.clipsToBounds = true
-        $0.layer.cornerRadius = 13
-    }
-
-    private let titleLabel = UILabel().then {
-        $0.font = .custom(.ns_b_16)
-        $0.textColor = .white
-        $0.numberOfLines = 2
-        $0.textAlignment = .center
-    }
-
-    private let subtitleLabel = UILabel().then {
-        $0.font = .custom(.ns_sb_9)
-        $0.textColor = .white
-        $0.numberOfLines = 2
-        $0.textAlignment = .center
-    }
+    private let imageView = UIImageView()
+    private let categoryLabel = UILabel.paddedLabel(top: 2, left: 10, bottom: 2, right: 10)
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let textStack = UIStackView()
 
     // MARK: - Override
 
+    override func setStyle() {
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 7
+        imageView.clipsToBounds = true
+
+        categoryLabel.font = .custom(.ns_sb_9)
+        categoryLabel.textColor = .black
+        categoryLabel.backgroundColor = .white
+        categoryLabel.textAlignment = .center
+        categoryLabel.clipsToBounds = true
+        categoryLabel.layer.cornerRadius = 13
+
+        titleLabel.font = .custom(.ns_b_16)
+        titleLabel.textColor = .white
+        titleLabel.numberOfLines = 2
+        titleLabel.textAlignment = .center
+
+        subtitleLabel.font = .custom(.ns_sb_9)
+        subtitleLabel.textColor = .white
+        subtitleLabel.numberOfLines = 2
+        subtitleLabel.textAlignment = .center
+
+        textStack.axis = .vertical
+        textStack.alignment = .center
+        textStack.spacing = 7
+    }
+
     override func setUI() {
-        contentView.addSubviews(
-            imageView,
-            categoryLabel,
-            titleLabel,
-            subtitleLabel
-        )
+        contentView.addSubview(imageView)
+        contentView.addSubview(textStack)
+        textStack.addArrangedSubviews(categoryLabel, titleLabel, subtitleLabel)
     }
 
     override func setLayout() {
@@ -59,26 +59,13 @@ final class HomeCardCell: BaseCollectionViewCell {
             $0.edges.equalToSuperview()
         }
 
-        let textStack = UIStackView(arrangedSubviews: [categoryLabel, titleLabel, subtitleLabel]).then {
-            $0.axis = .vertical
-            $0.alignment = .center
-            $0.spacing = 7
-        }
-
-        contentView.addSubview(textStack)
-
         textStack.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.leading.greaterThanOrEqualToSuperview().offset(16)
-            $0.trailing.lessThanOrEqualToSuperview().offset(-16)
+            $0.leading.trailing.equalToSuperview().inset(16)
         }
 
         categoryLabel.snp.makeConstraints {
             $0.height.greaterThanOrEqualTo(20)
-        }
-
-        titleLabel.snp.makeConstraints {
-            $0.width.lessThanOrEqualToSuperview().offset(-12)
         }
 
         subtitleLabel.snp.makeConstraints {

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Layout/CarouselFlowLayout.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Layout/CarouselFlowLayout.swift
@@ -1,0 +1,47 @@
+//
+//  CarouselFlowLayout.swift
+//  HYUNDAICARDDIVE_iOS
+//
+//  Created by 조영서 on 5/19/25.
+//
+
+import UIKit
+
+final class CarouselFlowLayout: UICollectionViewFlowLayout {
+
+    override init() {
+        super.init()
+        scrollDirection = .vertical
+        minimumLineSpacing = 16
+        sectionInset = UIEdgeInsets(top: 0, left: 30, bottom: 80, right: 30)
+        itemSize = CGSize(width: UIScreen.main.bounds.width - 60, height: 445)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        return true
+    }
+
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        guard let attributes = super.layoutAttributesForElements(in: rect),
+              let collectionView = collectionView else {
+            return nil
+        }
+
+        let centerY = collectionView.contentOffset.y + collectionView.bounds.height / 2
+
+        for attr in attributes {
+            let distance = abs(attr.center.y - centerY)
+            let normalized = distance / collectionView.bounds.height
+            let scale = 1 - (normalized * 0.2)
+
+            attr.transform = CGAffineTransform(scaleX: scale, y: scale)
+            attr.zIndex = Int((1 - normalized) * 10)
+        }
+
+        return attributes
+    }
+}

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Model/HomeCardModel.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Model/HomeCardModel.swift
@@ -1,0 +1,61 @@
+//
+//  HomeCardModel.swift
+//  HYUNDAICARDDIVE_iOS
+//
+//  Created by 조영서 on 5/17/25.
+//
+
+import Foundation
+
+struct HomeCardModel: Codable {
+    let imageUrl: String
+    let category: String
+    let title: String
+    let subtitle: String
+
+    enum CodingKeys: String, CodingKey {
+        case imageUrl
+        case category
+        case title
+        case subtitle = "hashTag"
+    }
+}
+
+let dummyCards: [HomeCardModel] = [
+    HomeCardModel(
+        imageUrl: "ios_img_contents_big1",
+        category: "쿠킹·고메",
+        title: "집밥은 아쉬운\n그런 날 있잖아",
+        subtitle: "신상 맛집 #21"
+    ),
+    HomeCardModel(
+        imageUrl: "ios_img_contents_big2",
+        category: "여행",
+        title: "예술 세계 속으로",
+        subtitle: "디깅 투어 #2\n대구·경주 건축 여행"
+    ),
+    HomeCardModel(
+        imageUrl: "ios_img_contents_big3",
+        category: "테크",
+        title: "집안일 해방일지",
+        subtitle: "살림을 도와줄\n스마트 홈 아이템 3"
+    ),
+    HomeCardModel(
+        imageUrl: "ios_img_contents_big4",
+        category: "건축·인테리어",
+        title: "식탁에도\n새 옷으로",
+        subtitle: "멋을 더해 줄 주방 아이템"
+    ),
+    HomeCardModel(
+        imageUrl: "ios_img_contents_big5",
+        category: "스타일",
+        title: "남다른 쇼핑",
+        subtitle: "집처럼 친근한\n브랜드 공간 공간 탐험 3"
+    ),
+    HomeCardModel(
+        imageUrl: "ios_img_contents_big6",
+        category: "쿠킹·고메",
+        title: "여름 한입",
+        subtitle: "[맛집 모음zip]\n지역별 특별한 빙수집 8"
+    )
+]

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Model/HomeSlideModel.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/Model/HomeSlideModel.swift
@@ -52,4 +52,10 @@ let dummySlides: [HomeSlideModel] = [
         title: "남다른\n쇼핑",
         subtitle: "집처럼 친근한 브랜드 공간 공간 탐험 3"
     ),
+    HomeSlideModel(
+        imageUrl: "ios_img_contents_big6",
+        category: "쿠킹·고메",
+        title: "여름\n한입",
+        subtitle: "[맛집 모음zip] 지역별 특별한 빙수집 8"
+    )
 ]

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/View/HomeCardView.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/View/HomeCardView.swift
@@ -1,0 +1,89 @@
+//
+//  HomeCardView.swift
+//  HYUNDAICARDDIVE_iOS
+//
+//  Created by 조영서 on 5/19/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class HomeCardView: BaseView {
+
+    // MARK: - Properties
+
+    private var cards: [HomeCardModel] = []
+
+    // MARK: - UI
+
+    private lazy var layout = UICollectionViewFlowLayout().then {
+        let spacing: CGFloat = 9
+        let horizontalInset: CGFloat = 30
+        let totalSpacing = spacing + horizontalInset * 2
+        let itemWidth = (UIScreen.main.bounds.width - totalSpacing) / 2
+        $0.scrollDirection = .vertical
+        $0.minimumLineSpacing = 12
+        $0.minimumInteritemSpacing = spacing
+        $0.itemSize = CGSize(width: itemWidth, height: 248)
+        $0.sectionInset = UIEdgeInsets(top: 0, left: horizontalInset, bottom: 0, right: horizontalInset)
+    }
+
+    private lazy var collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: layout
+    ).then {
+        $0.showsVerticalScrollIndicator = false
+        $0.isPagingEnabled = false
+        $0.register(HomeCardCell.self, forCellWithReuseIdentifier: "HomeCardCell")
+        $0.delegate = self
+        $0.dataSource = self
+        $0.backgroundColor = .clear
+    }
+
+    // MARK: - Setup
+
+    override func setUI() {
+        addSubview(collectionView)
+    }
+
+    override func setLayout() {
+        collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(96)
+        }
+    }
+
+    // MARK: - Data Binding
+
+    func setData(_ data: [HomeCardModel]) {
+        cards = data
+        collectionView.reloadData()
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+
+extension HomeCardView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return cards.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: "HomeCardCell",
+            for: indexPath
+        ) as? HomeCardCell else {
+            return UICollectionViewCell()
+        }
+        cell.configure(with: cards[indexPath.item])
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension HomeCardView: UICollectionViewDelegateFlowLayout {}

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/View/HomeSlideView.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/View/HomeSlideView.swift
@@ -21,7 +21,7 @@ final class HomeSlideView: BaseView, UICollectionViewDelegate {
     private let collectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: {
-            let layout = UICollectionViewFlowLayout()
+            let layout = CarouselFlowLayout()
             layout.scrollDirection = .vertical
             layout.minimumLineSpacing = 16
             layout.itemSize = CGSize(width: UIScreen.main.bounds.width - 60, height: 445)

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/View/HomeView.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/View/HomeView.swift
@@ -20,7 +20,7 @@ final class HomeView: BaseView {
     private let spacing25_2 = UIView()
     private let stackView = UIStackView()
     private let searchImageView = UIImageView()
-    
+
     let categoryCollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: {
@@ -33,7 +33,8 @@ final class HomeView: BaseView {
     )
 
     let switchButton = UIButton()
-    let slideView = HomeSlideView()
+
+    let contentContainer = UIView()
 
     // MARK: - Setup
 
@@ -42,7 +43,7 @@ final class HomeView: BaseView {
             stackView,
             searchImageView,
             categoryCollectionView,
-            slideView,
+            contentContainer,
             switchButton
         )
 
@@ -90,6 +91,8 @@ final class HomeView: BaseView {
         }
 
         switchButton.contentMode = .scaleAspectFit
+
+        contentContainer.backgroundColor = .clear
     }
 
     override func setLayout() {
@@ -115,10 +118,9 @@ final class HomeView: BaseView {
             $0.height.equalTo(36)
         }
 
-        slideView.snp.makeConstraints {
+        contentContainer.snp.makeConstraints {
             $0.top.equalTo(categoryCollectionView.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
 

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -16,6 +16,10 @@ final class HomeViewController: BaseViewController {
     private let rootView = HomeView()
     private let categories = ["전체", "디자인·아트", "건축·인테리어", "여행", "음악", "쿠킹·고메", "스타일", "테크", "스페셜"]
     private var selectedIndex = 0
+    private var isCardViewShown = false
+
+    private let slideView = HomeSlideView()
+    private let cardView = HomeCardView()
 
     private let floatingButton = UIButton().then {
         let resizedImage = UIImage(named: "ic_home_align1")?.resize(targetSize: CGSize(width: 40, height: 40))
@@ -38,6 +42,7 @@ final class HomeViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupFloatingButton()
+        showInitialSlideView()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -46,7 +51,6 @@ final class HomeViewController: BaseViewController {
     }
 
     override func setView() {
-        rootView.slideView.setData(dummySlides)
         rootView.suggestionButton.addTarget(self, action: #selector(didTapSuggestion), for: .touchUpInside)
         rootView.recentButton.addTarget(self, action: #selector(didTapRecent), for: .touchUpInside)
     }
@@ -56,7 +60,7 @@ final class HomeViewController: BaseViewController {
         rootView.categoryCollectionView.dataSource = self
     }
 
-    // MARK: - Setup Floating Button
+    // MARK: - Setup Views
 
     private func setupFloatingButton() {
         view.addSubview(floatingButton)
@@ -69,7 +73,23 @@ final class HomeViewController: BaseViewController {
         floatingButton.addTarget(self, action: #selector(didTapFloatingButton), for: .touchUpInside)
     }
 
-    // MARK: - Button Actions
+    private func showInitialSlideView() {
+        rootView.contentContainer.addSubview(slideView)
+        slideView.setData(dummySlides)
+        slideView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+
+    private func showCardView() {
+        rootView.contentContainer.addSubview(cardView)
+        cardView.setData(dummyCards)
+        cardView.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+
+    private func clearCurrentContentView() {
+        rootView.contentContainer.subviews.forEach { $0.removeFromSuperview() }
+    }
+
+    // MARK: - Actions
 
     @objc private func didTapSuggestion() {
         rootView.updateButtonStyle(isSuggestionSelected: true)
@@ -80,11 +100,18 @@ final class HomeViewController: BaseViewController {
     }
 
     @objc private func didTapFloatingButton() {
-        floatingButton.isSelected.toggle()
+        isCardViewShown.toggle()
 
-        let imageName = floatingButton.isSelected ? "ic_home_align2" : "ic_home_align1"
+        let imageName = isCardViewShown ? "ic_home_align2" : "ic_home_align1"
         let resizedImage = UIImage(named: imageName)?.resize(targetSize: CGSize(width: 40, height: 40))
         floatingButton.setImage(resizedImage, for: .normal)
+
+        clearCurrentContentView()
+        if isCardViewShown {
+            showCardView()
+        } else {
+            showInitialSlideView()
+        }
     }
 }
 
@@ -133,4 +160,3 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
 #Preview {
     HomeViewController()
 }
-

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -156,7 +156,3 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
         return CGSize(width: width, height: 32)
     }
 }
-
-#Preview {
-    HomeViewController()
-}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- closed: #36 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 슬라이드 → 카드 뷰 전환 버튼 구현
- 카드 뷰 레이아웃 구현 (무한 스크롤은 미적용)
- 슬라이드 뷰에 스크롤 애니메이션 효과 추가

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| 뷰 전환 + 애니메이션 | <img src = "https://github.com/user-attachments/assets/95c16e1c-ff58-45b2-b7e4-fb780cafa33e" width ="250"> | <img src = "https://github.com/user-attachments/assets/baefc1e7-23df-4426-89d0-ba216a8b32c2" width ="250"> |

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
https://demian-develop.tistory.com/21

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
기존 뷰 스케치에서는 collectionView.setCollectionViewLayout(_:animated:)을 활용해 동일한 컬렉션 뷰에서 레이아웃만 전환하는 방식으로 구현하고자 했습니다. 하지만 카드 뷰와 슬라이드 뷰 간의 폰트 크기, 전체 레이아웃 구성 등 세부 차이점이 많아 if 문이 늘어나서 복잡해지더라구요😥 그래서 카드 뷰를 별도 분리하여 관리하는 방식으로 전환했습니다!

또한, 커스텀 애니메이션 효과를 UICollectionView에 직접 적용하는 데 한계가 있어 현재 구조로 대체 구현한 점 참고 부탁드립니다.
더 좋은 방식이나 개선 아이디어가 있다면 편하게 말씀해 주세요! 😊