### PR TITLE
[feat/#43] Space&Culture 진입 화면 네트워크 연결

### DIFF
--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Global/Utils/DataBindableCell.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Global/Utils/DataBindableCell.swift
@@ -1,3 +1,4 @@
 protocol DataBindableCell {
-    func dataBind(row: Int)
+    associatedtype DataType
+    func dataBind(item: DataType)
 }

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Network/DTO/SpaceCulture/SpaceCultureResponseDto.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Network/DTO/SpaceCulture/SpaceCultureResponseDto.swift
@@ -1,0 +1,13 @@
+struct SpaceCultureResponseDto: Decodable {
+    let dataList: [WhatsOn]
+}
+
+struct WhatsOn: Decodable {
+    let date: String
+    let title: String
+    let description: String
+    let stage: String
+    let location: String
+    let reservation: Bool
+    let image: String
+}

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Network/Service/SpaceCulture/SpaceCultureService.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Network/Service/SpaceCulture/SpaceCultureService.swift
@@ -1,0 +1,4 @@
+final class SpaceCultureService: BaseService {
+    typealias Response = SpaceCultureResponseDto
+    var api: APIType = .culture
+}

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/Cell/CultureCell.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/Cell/CultureCell.swift
@@ -2,8 +2,8 @@ import UIKit
 
 final class CultureCell: BaseCollectionViewCell, DataBindableCell {
     
-    private let cultureData = CultureModel.makeData()
-    
+    typealias DataType = CultureModel
+        
     private let cultureImageView = UIImageView()
     private let descriptionLabel = UILabel()
     
@@ -40,8 +40,8 @@ final class CultureCell: BaseCollectionViewCell, DataBindableCell {
         }
     }
     
-    func dataBind(row: Int) {
-        cultureImageView.image = cultureData[row].image.resize(targetSize: CGSize(width: 64, height: 40))
-        descriptionLabel.text = cultureData[row].description
+    func dataBind(item: CultureModel) {
+        cultureImageView.image = item.image.resize(targetSize: CGSize(width: 64, height: 40))
+        descriptionLabel.text = item.description
     }
 }

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/Cell/SpaceCell.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/Cell/SpaceCell.swift
@@ -2,8 +2,8 @@ import UIKit
 
 final class SpaceCell: BaseCollectionViewCell, DataBindableCell {
     
-    private let spaceData = SpaceModel.makeData()
-    
+    typealias DataType = SpaceModel
+        
     private let spaceImageView = UIImageView()
     private let descriptionLabel = UILabel()
     private let spaceStackView = UIStackView()
@@ -41,8 +41,8 @@ final class SpaceCell: BaseCollectionViewCell, DataBindableCell {
         }
     }
     
-    func dataBind(row: Int) {
-        spaceImageView.image = spaceData[row].image.resize(targetSize: CGSize(width: 66, height: 26))
-        descriptionLabel.text = spaceData[row].description
+    func dataBind(item: SpaceModel) {
+        spaceImageView.image = item.image.resize(targetSize: CGSize(width: 66, height: 26))
+        descriptionLabel.text = item.description
     }
 }

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/Cell/WhatsOnCell.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/Cell/WhatsOnCell.swift
@@ -2,8 +2,8 @@ import UIKit
 
 final class WhatsOnCell: BaseCollectionViewCell, DataBindableCell {
     
-    private let whatsOnData = WhatsOnModel.makeData()
-    
+    typealias DataType = WhatsOn
+        
     private let dotView = UIImageView()
     private let timeLineView = UIView()
     private let timeLineStackView = UIStackView()
@@ -112,13 +112,13 @@ final class WhatsOnCell: BaseCollectionViewCell, DataBindableCell {
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(dateLabel.snp.bottom).offset(4)
             $0.leading.equalToSuperview()
-            $0.width.equalTo(150)
+            $0.width.equalTo(185)
         }
         
         descriptionLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(6)
             $0.leading.equalToSuperview()
-            $0.width.equalTo(190)
+            $0.width.equalTo(200)
         }
         
         locationAndReservationStackView.snp.makeConstraints {
@@ -149,20 +149,21 @@ final class WhatsOnCell: BaseCollectionViewCell, DataBindableCell {
         }
     }
     
-    func dataBind(row: Int) {
-        dateLabel.text = whatsOnData[row].date
-        titleLabel.text = whatsOnData[row].title
-        descriptionLabel.text = whatsOnData[row].description
-        stageLabel.text = whatsOnData[row].stage
-        locationLabel.text = whatsOnData[row].location
+    func dataBind(item: WhatsOn) {
+        dateLabel.text = item.date
+        titleLabel.text = item.title
+        descriptionLabel.text = item.description
+        stageLabel.text = item.stage
+        locationLabel.text = item.location
         
-        if whatsOnData[row].isReserved {
+        if item.reservation {
             reservationLabel.text = "예매"
         } else {
             locationReservationDivideLine.isHidden = true
             reservationLabel.isHidden = true
         }
         
-        programImageView.image = whatsOnData[row].image.resize(targetSize: CGSize(width: 90, height: 90))
+        let url = URL(string: item.image)
+        programImageView.kf.setImage(with: url)
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- closed: #43

## 📄 작업 내용
- /api/culture에 해당하는 API 연동하여 What's On 섹션에 해당하는 데이터 바인딩

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| What's On 섹션 데이터 바인딩 | <img src = "https://github.com/user-attachments/assets/700a3d84-dc48-43fa-9de1-85abfb0d55e2" width ="250"> | <img src = "https://github.com/user-attachments/assets/bd251127-8872-4e71-aedf-1ab4829d5e18" width ="250"> |

## 💻 주요 코드 설명
### 네트워크 연동

- DTO 설정

<details>
<summary>SpaceCultureResponseDto</summary>

```swift
struct SpaceCultureResponseDto: Decodable {
    let dataList: [WhatsOn]
}

struct WhatsOn: Decodable {
    let date: String
    let title: String
    let description: String
    let stage: String
    let location: String
    let reservation: Bool
    let image: String
}
```
</details>

- SpaceCultureService 설정 : BaseService 상속

<details>
<summary> SpaceCultureService </summary>

```swift
final class SpaceCultureService: BaseService {
    typealias Response = SpaceCultureResponseDto
    var api: APIType = .culture
}
```
</details>

- 실제 데이터 fetch 해오기

<details>
<summary> SpaceCultureViewController </summary>

```swift
extension SpaceCultureViewController {
    func fetchWhatsOn() async {
        do {
            let data = try await spaceCultureService.fetch()
            whatsOnItems = data.dataList
            
            DispatchQueue.main.async {
                self.spaceCultureView.collectionView.reloadData()
            }
        } catch {
            print("❌ 데이터 로딩 실패: \(error.localizedDescription)")
        }
    }
}
```
</details>
<br>

### 기존의 DataBindableCell 프로토콜 변경

- dataBind 메서드 : indexPath의 row를 넘겨주는 방식에서 데이터(item) 자체를 넘겨주는 방식으로 변경

<details>
<summary> DataBindableCell </summary>

```swift
protocol DataBindableCell {
    associatedtype DataType
    func dataBind(item: DataType)
}

// 실제 사용 사례 : SpaceCultureViewController
// dequeCell : 섹션이 What's on인지, Space인지, Culture인지에 따라 자기 섹션에 해당하는 셀을 deque하는 메서드
private func dequeCell<T: BaseCollectionViewCell & DataBindableCell>(
    _ type: T.Type,
    indexPath: IndexPath,
    from collectionView: UICollectionView,
    item: [T.DataType]
) -> T {
    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: T.reuseIdentifier, for: indexPath) as! T
    
    // dataBind 파라미터로 데이터 자체를 넘김
    cell.dataBind(item: item[indexPath.row])
    return cell
}
```
</details>

## 📚 참고자료
- ⭐️리드 현수의 엄청난 네트워크 세팅 코드
