### PR TITLE
[refactor/#48] createGroup 메서드 활용

### DIFF
--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/SpaceCultureCompositionalLayoutFactory.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/SpaceCultureCompositionalLayoutFactory.swift
@@ -43,12 +43,10 @@ extension SpaceCultureCompositionalLayoutFactory {
             heightDimension: .absolute(148)
         )
         
-        let group = NSCollectionLayoutGroup.vertical(
-            layoutSize: NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(148)
-            ),
-            subitems: [item]
+        let group =  createGroup(
+            items: [item],
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(148)
         )
         
         let section = createSection(

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/SpaceCultureCompositionalLayoutFactory.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/SpaceCultureCompositionalLayoutFactory.swift
@@ -9,7 +9,8 @@ enum SectionType: Int, CaseIterable {
 class SpaceCultureCompositionalLayoutFactory: BaseCompositionalLayoutFactory {
     
     func create() -> UICollectionViewCompositionalLayout {
-        let layout = UICollectionViewCompositionalLayout { [self] (sectionIndex, _) -> NSCollectionLayoutSection? in
+        let layout = UICollectionViewCompositionalLayout { [self] (sectionIndex, _) ->
+            NSCollectionLayoutSection? in
             guard let section: SectionType = SectionType(rawValue: sectionIndex) else {
                 return nil
             }

--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/SpaceCultureCompositionalLayoutFactory.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/SpaceCultureCompositionalLayoutFactory.swift
@@ -73,21 +73,17 @@ extension SpaceCultureCompositionalLayoutFactory {
             contentInsets: .init(top: 4, leading: 4, bottom: 4, trailing: 4)
         )
 
-        let horizontalGroup = NSCollectionLayoutGroup.horizontal(
-            layoutSize: NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(123)
-            ),
-            subitems: Array(repeating: item, count: 3)
+        let horizontalGroup = createGroup(
+            items: Array(repeating: item, count: 3),
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(123)
         )
         horizontalGroup.interItemSpacing = .fixed(31)
 
-        let verticalGroup = NSCollectionLayoutGroup.vertical(
-            layoutSize: NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(428)
-            ),
-            subitems: [horizontalGroup]
+        let verticalGroup = createGroup(
+            items: [horizontalGroup],
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(428)
         )
         verticalGroup.contentInsets.bottom = 12
 


### PR DESCRIPTION
## 🔗 연결된 이슈
- closed: #48

## 💻 주요 코드 설명
### SpaceCultureCompositionalLayoutFactory에서 createGroup 메서드 호출

<details>
<summary> SpaceCultureCompositionalLayoutFactory </summary>

```swift
// SpaceCultureCompositionalLayoutFactory 중
extension SpaceCultureCompositionalLayoutFactory {
    
    private func createWhatsOnSection() -> NSCollectionLayoutSection {
        let header = createBoundarySupplementaryItem(
            type: .header,
            widthDimension: .fractionalWidth(1.0),
            heightDimension: .absolute(30),
            alignment: .top
        )
        
        let item = createItem(
            widthDimension: .fractionalWidth(1.0),
            heightDimension: .absolute(148)
        )
        
        let group =  createGroup(
            items: [item],
            widthDimension: .fractionalWidth(1.0),
            heightDimension: .absolute(148)
        )
        
        let section = createSection(
            group: group,
            sectionContentInsets: .init(top: 40, leading: 32, bottom: 12, trailing: 32),
            boundarySupplementaryItems: [header]
        )
        return section
    }
    
    private func createThreeColumnGridSection() -> NSCollectionLayoutSection {
        let header = createBoundarySupplementaryItem(
            type: .header,
            widthDimension: .fractionalWidth(1.0),
            heightDimension: .absolute(30),
            alignment: .top
        )

        let item = createItem(
            widthDimension: .fractionalWidth(1.0 / 3.0),
            heightDimension: .absolute(120),
            contentInsets: .init(top: 4, leading: 4, bottom: 4, trailing: 4)
        )

        let horizontalGroup = createGroup(
            items: Array(repeating: item, count: 3),
            widthDimension: .fractionalWidth(1.0),
            heightDimension: .estimated(123)
        )
        horizontalGroup.interItemSpacing = .fixed(31)

        let verticalGroup = createGroup(
            items: [horizontalGroup],
            widthDimension: .fractionalWidth(1.0),
            heightDimension: .estimated(428)
        )
        verticalGroup.contentInsets.bottom = 12

        let section = createSection(
            group: verticalGroup,
            sectionContentInsets: .init(top: 40, leading: 32, bottom: 12, trailing: 32),
            boundarySupplementaryItems: [header]
        )

        return section
    }

}

```
</details>