### PR TITLE
[refactor/#55] Space&Culture 상세 화면 스크롤 오류 해결

### DIFF
--- a/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/View/SpaceCultureDetailView.swift
+++ b/HYUNDAICARDDIVE_iOS/HYUNDAICARDDIVE_iOS/Presentation/SpaceCulture/View/SpaceCultureDetailView.swift
@@ -17,10 +17,10 @@ final class SpaceCultureDetailView: BaseView {
     }
     
     override func setUI() {
-        contentStackView.addArrangedSubviews(designLibraryHeaderView, designLibraryMenuView, designLibraryCheckInView, articleView)
-        
+        contentStackView.addArrangedSubviews(
+            designLibraryHeaderView, designLibraryMenuView, designLibraryCheckInView, articleView
+        )
         scrollView.addSubview(contentStackView)
-        
         addSubview(scrollView)
     }
     
@@ -51,7 +51,7 @@ final class SpaceCultureDetailView: BaseView {
             $0.top.equalTo(designLibraryCheckInView.snp.bottom).offset(10)
             $0.centerX.equalToSuperview()
             $0.width.equalToSuperview()
-            $0.height.equalTo(422)
+            $0.height.equalTo(490)
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- closed: #55

## 📄 작업 내용
- articleView 높이 재설정으로 Space&Culture 상세화면에서 스크롤할 시 아티클 내용이 모두 보이도록 변경

|    구현 내용    |   iPhone 13 mini   |   iPhone 15 pro   |
| :-------------: | :----------: | :----------: |
| articleView 높이 수정 | <img src = "https://github.com/user-attachments/assets/5bc7a73a-edb1-4b1f-986d-527171f20092" width ="250"> | <img src = "https://github.com/user-attachments/assets/5bc7a73a-edb1-4b1f-986d-527171f20092" width ="250"> |